### PR TITLE
Add more arguments and vars. And show curl errors when there are …

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,31 @@ environment.
 
 Using the script is straightforward. To backup JIRA:
 
-    ./backup.sh jira
+    ./backup.sh --source jira
 
 To backup Confluence (wiki):
 
-    ./backup.sh wiki
+    ./backup.sh --source wiki
+
+To backup JIRA without attachments:
+
+    ./backup.sh --source jira --attachments false
+
+Arguments overview:
+
+* -a, --attachments
+
+     Set if attachments should be in the backup. Values are "true" (default) or "false".
+
+* -s, --source
+
+    Set what backup should be created. Default source is Jira. Set the argument to "wiki" or "confluence" to backup Confluence.
+
+* -t, --timestamp
+
+    Set if we should overwrite the previous backup or append a timestamp (default) to prevent just that.
+    The former is useful when an external backup program handles backup rotation.
+    Set the argument to "false" if there should be no timestamp in the filename.
 
 # Implementation
 

--- a/backup.sh.vars.example
+++ b/backup.sh.vars.example
@@ -12,3 +12,8 @@ TIMESTAMP=true
 # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 TIMEZONE=America/Los_Angeles
 
+# Set how many seconds to sleep till the next check if the backup is ready to download
+SLEEP_SECONDS=10
+
+# Set how often the progress of the backup should be checked before to exit the script.
+PROGRESS_CHECKS=20


### PR DESCRIPTION
… issues with downloading the backup file.

Arguments overview:

* -a, --attachments

     Set if attachments should be in the backup. Values are "true" (default) or "false".

* -s, --source

    Set what backup should be created. Default source is Jira. Set the argument to "wiki" or "confluence" to backup Confluence.

* -t, --timestamp

    Set if we should overwrite the previous backup or append a timestamp (default) to prevent just that.
    The former is useful when an external backup program handles backup rotation.
    Set the argument to "false" if there should be no timestamp in the filename.

Vars overview:

SLEEP_SECONDS : Set how many seconds to sleep till the next check if the backup is ready to download
PROGRESS_CHECKS : Set how often the progress of the backup should be checked before to exit the script.