### PR TITLE
Fix instance path for the backup, progress and download url.

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -7,6 +7,7 @@ FILEPREFIX="JIRA"
 if [ -r "$CONFIG" ]; then
     . $CONFIG
     DOWNLOAD_URL="https://${INSTANCE}"
+    INSTANCE_PATH=$INSTANCE
 else
     echo "Usable to load $CONFIG! Please create one based on backup.sh.vars.example"
     exit 1

--- a/backup.sh
+++ b/backup.sh
@@ -19,8 +19,8 @@ do
     case $key in
         -s|--source)
             if [[  $2 == "wiki" ]] || [[ $2 == "confluence" ]]; then
-                INSTANCE=$INSTANCE/wiki
-                DOWNLOAD_URL="https://${INSTANCE}/download"
+                INSTANCE_PATH=$INSTANCE/wiki
+                DOWNLOAD_URL="https://${INSTANCE_PATH}/download"
                 FILEPREFIX="CONFLUENCE"
             fi
             shift # past argument
@@ -43,8 +43,8 @@ do
 done
 
 BASENAME=$1
-RUNBACKUP_URL="https://${INSTANCE}/rest/obm/1.0/runbackup"
-PROGRESS_URL="https://${INSTANCE}/rest/obm/1.0/getprogress.json"
+RUNBACKUP_URL="https://${INSTANCE_PATH}/rest/obm/1.0/runbackup"
+PROGRESS_URL="https://${INSTANCE_PATH}/rest/obm/1.0/getprogress.json"
 
 # Grabs cookies and generates the backup on the UI. 
 TODAY=$(TZ=$TIMEZONE date +%Y%m%d)


### PR DESCRIPTION
I created a bug, here is the fix for it. 
When chosen source is "confluence" i had set the INSTANCE var at beginning to a subdirectory. Because of this the cookie creation failed and you got an "authorization failure".