### PR TITLE
Fix #2 Change umask so all generated files are only readable by owner

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -4,6 +4,8 @@ CONFIG="$HOME/.backup.sh.vars"
 ATTACHMENTS="true"
 FILEPREFIX="JIRA"
 
+umask 0077 
+
 if [ -r "$CONFIG" ]; then
     . $CONFIG
     DOWNLOAD_URL="https://${INSTANCE}"


### PR DESCRIPTION
This will change the perms for all files, including cookie and backups themselves.