### PR TITLE
Fix attachment variable

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -73,7 +73,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # The $BKPMSG variable will print the error message, you can use it if you're planning on sending an email
-BKPMSG=$(curl -s --cookie $COOKIE_FILE_LOCATION --header "X-Atlassian-Token: no-check" -H "X-Requested-With: XMLHttpRequest" -H "Content-Type: application/json"  -X POST $RUNBACKUP_URL -d '{"cbAttachments":"${ATTACHMENTS}" }' )
+BKPMSG=$(curl -s --cookie $COOKIE_FILE_LOCATION --header "X-Atlassian-Token: no-check" -H "X-Requested-With: XMLHttpRequest" -H "Content-Type: application/json"  -X POST $RUNBACKUP_URL -d "{\"cbAttachments\":\"${ATTACHMENTS}\" }" )
 
 # Checks if we were authorized to create a new backup
 if [ "$(echo "$BKPMSG" | grep -c Unauthorized)" -ne 0 ]  || [ "$(echo "$BKPMSG" | grep -ic "<status-code>401</status-code>")" -ne 0 ]; then


### PR DESCRIPTION
Fix attachment variable, that does not work in single quotes.

Script is tested.. Download of 5 GB confluence backup works well. 
However: on another maschine the script breaks after some time with 

    curl: (18) transfer closed with 3043270005 bytes remaining to read

But this is another topic which i must still debug.